### PR TITLE
Bump Ayowel/butler-to-itch action to v1.2.0

### DIFF
--- a/.github/workflows/static-version-deployment.yml
+++ b/.github/workflows/static-version-deployment.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Build for itch.io
         run: bun run build:itch
       - name: Publish to itch.io
-        uses: Ayowel/butler-to-itch@v1.1.1
+        uses: Ayowel/butler-to-itch@v1.2.0
         with:
           butler_key: ${{ secrets.ITCH_IO_API_KEY }}
           itch_user: ${{ secrets.ITCH_IO_USERNAME }}


### PR DESCRIPTION
Update .github/workflows/static-version-deployment.yml to use Ayowel/butler-to-itch@v1.2.0 for the "Publish to itch.io" step (previously v1.1.1). This upgrades the GitHub Action to the newer patch release to incorporate upstream fixes or improvements.