### PR TITLE
Add 'itch' platform option

### DIFF
--- a/src/core/managers/platform.manager.ts
+++ b/src/core/managers/platform.manager.ts
@@ -3,7 +3,7 @@ import { CrazyStrategy } from '@src/platforms/strategies/crazy.strategy.ts';
 
 export class PlatformManager {
   private static instance: PlatformManager;
-  private readonly platforms: Record<'development' | 'github' | 'crazy', Platform>;
+  private readonly platforms: Record<'development' | 'github' | 'crazy' | 'itch', Platform>;
   private readonly platform: Platform;
 
   private constructor() {
@@ -11,6 +11,7 @@ export class PlatformManager {
       development: new Platform(),
       github: new Platform(),
       crazy: new CrazyStrategy(),
+      itch: new Platform(),
     };
 
     switch (import.meta.env.VITE_PLATFORM) {
@@ -22,6 +23,9 @@ export class PlatformManager {
         break;
       case 'crazy':
         this.platform = this.platforms.crazy;
+        break;
+      case 'itch':
+        this.platform = this.platforms.itch;
         break;
       default:
         throw new Error(`Unknown platform mode: ${import.meta.env.VITE_PLATFORM}`);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,7 +6,7 @@ interface ImportMetaEnv {
   VITE_DESCRIPTION: string;
   VITE_RELEASE_VERSION: string;
   VITE_INCLUDE_SDK: 'YES' | 'NO';
-  VITE_PLATFORM: 'development' | 'github' | 'crazy';
+  VITE_PLATFORM: 'development' | 'github' | 'crazy' | 'itch';
 }
 
 // declare global {


### PR DESCRIPTION
Register an 'itch' platform and recognize it via VITE_PLATFORM. PlatformManager now includes an 'itch' entry (default Platform instance) and a corresponding switch case, and vite-env.d.ts extends the VITE_PLATFORM union to include 'itch'. This lets the app be built/run with VITE_PLATFORM=itch (uses the default Platform strategy for now).